### PR TITLE
Fix ip error in github ci

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,12 +13,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: apt update
+      run: sudo apt update
     
     - name: Install apt packages
       working-directory: ./tests
-      run: |
-        sudo apt update \
-        xargs -a apt_requirements.txt sudo apt-get install -y
+      run: xargs -a apt_requirements.txt sudo apt-get install -y
 
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v3

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,7 +16,9 @@ jobs:
     
     - name: Install apt packages
       working-directory: ./tests
-      run: xargs -a apt_requirements.txt sudo apt-get install -y
+      run: |
+        sudo apt update \
+        xargs -a apt_requirements.txt sudo apt-get install -y
 
     - name: Install Python dependencies
       uses: py-actions/py-dependency-install@v3


### PR DESCRIPTION
Fix ip error in Github CI.

It is likely because sudo apt update wasn't done first.